### PR TITLE
Added load cartridge collection job creating folders for each cartridge

### DIFF
--- a/projects/jobs/jobs.groovy
+++ b/projects/jobs/jobs.groovy
@@ -55,8 +55,16 @@ export GIT_SSH="${WORKSPACE}/custom_ssh"
 # Clone Cartridge
 git clone ${CARTRIDGE_CLONE_URL} cartridge
 
-repo_namespace="${PROJECT_NAME}"
-permissions_repo="${repo_namespace}/permissions"
+permissions_repo="${PROJECT_NAME}/permissions"
+
+# Check if folder was specified
+if [ -z ${CARTRIDGE_FOLDER} ] ; then
+    echo "Folder name not specified..."
+    repo_namespace="${PROJECT_NAME}"
+else
+    echo "Folder name specified, changing project namespace value.."
+    repo_namespace="${PROJECT_NAME}/${CARTRIDGE_FOLDER}"
+fi
 
 # Create repositories
 mkdir ${WORKSPACE}/tmp


### PR DESCRIPTION
- Updated Load_Cartridge with parameters to specify folder (name, display name and description). If all parameters are specified, will create folder in project and load cartridge in there.

- Added new job to load cartridge collections. Collection specified via JSON file, example [here](https://raw.githubusercontent.com/dsingh07/adop-cartridge-collections/master/example.json). Job parses JSON and then just calls Load_Cartridge, creating folders for each cartridge.