### PR TITLE
Fixed support of Cartridge groovy utilities

### DIFF
--- a/projects/jobs/jobs.groovy
+++ b/projects/jobs/jobs.groovy
@@ -135,7 +135,7 @@ fileList.each {
 }
 ''')
         dsl {
-            external("cartridge/jenkins/jobs/dsl/**/*.groovy")
+            external("cartridge/jenkins/jobs/dsl/*.groovy")
         }
 
     }


### PR DESCRIPTION
I'm not sure why, but right now "Load_Cartridge" Jenkins job trying to load every *.groovy file even in sub-folders and turns out that this is a bad thing, because of this, we can't support https://github.com/jenkinsci/job-dsl-plugin/blob/master/docs/Real-World-Examples.md#import-other-files-ie-with-class-definitions-into-your-script

My suggestion is to remove recursive scanning to have an ability load external groovy scripts from sub-folders.

I already rewrote and tested Java cartridge, example:
```
/jenkins
-/jobs
--/dsl
---/java_reference_application_jobs.groovy
---/environment_provisioning.groovy
---/utilities
----/CartridgeUtilities.groovy
``` 

**java_reference_application_jobs.groovy**
```groovy
import utilities.CartridgeUtilities

def deployJob = freeStyleJob(projectFolderName + "/Reference_Application_Deploy")
def deployJobToProdA = freeStyleJob(projectFolderName + "/Reference_Application_Deploy_ProdA")
def deployJobToProdB = freeStyleJob(projectFolderName + "/Reference_Application_Deploy_ProdB")

// Add steps with copying artifacts and shell block
def deploymentJobs = [deployJob, deployJobToProdA, deployJobToProdB]
deploymentJobs.each {
    CartridgeUtilities.addDeploymentSteps(it)
}
```

**CartridgeUtilities.groovy**
```groovy
package utilities

class CartridgeUtilities {
    static void addDeploymentSteps(def job) {
        job.with {
            steps {
                copyArtifacts("Reference_Application_Build") {
                    buildSelector {
                        buildNumber('${B}')
                        includePatterns('target/petclinic.war')
                    }
                }
                shell('''export SERVICE_NAME="$(echo ${PROJECT_NAME} | tr '/' '_')_${ENVIRONMENT_NAME}"
                    |
                    |docker cp ${WORKSPACE}/target/petclinic.war  ${SERVICE_NAME}:/usr/local/tomcat/webapps/
                    |docker restart ${SERVICE_NAME}
                    |COUNT=1
                    |while ! curl -q http://${SERVICE_NAME}:8080/petclinic -o /dev/null
                    |do
                    |    if [ ${COUNT} -gt 10 ]; then
                    |       echo "Docker build failed even after ${COUNT}. Please investigate."
                    |       exit 1
                    |    fi
                    |    echo "Application is not up yet. Retrying ..Attempt (${COUNT})"
                    |    sleep 5
                    |    COUNT=$((COUNT+1))
                    |done
                    |echo "=.=.=.=.=.=.=.=.=.=.=.=."
                    |echo "=.=.=.=.=.=.=.=.=.=.=.=."
                    |echo "Environment URL (replace PUBLIC_IP with your public ip address where you access jenkins from) : http://${SERVICE_NAME}.PUBLIC_IP.xip.io/petclinic"
                    |echo "=.=.=.=.=.=.=.=.=.=.=.=."
                    |echo "=.=.=.=.=.=.=.=.=.=.=.=."
                    |set -x'''.stripMargin()
                )
            }
        }
    }
}
```

We can reduce code base of cartridges in... i don't know 4-5 times. In example which i provided above, was reduced 90 lines of code.

So far i founded 2 options how we can achieve this, or accept my PR or "add Additional Classpath (under Advanced) to src/main/groovy." https://github.com/sheehan/job-dsl-gradle-example/issues/2#issuecomment-64650773

As an option, "CartridgeUtilities" can be part of "Platform Management" and all cartridges will just use import and use provided methods from base class. 
```
import utilities.*
```