### PR TITLE
Fixing platform jobs to a set version of adop-platform-management

### DIFF
--- a/bootstrap/Platform_Management/Load_Cartridge_List.groovy
+++ b/bootstrap/Platform_Management/Load_Cartridge_List.groovy
@@ -4,6 +4,14 @@ def platformToolsGitURL = "ssh://jenkins@gerrit:29418/platform-management"
 def platformManagementFolderName= "/Platform_Management"
 def platformManagementFolder = folder(platformManagementFolderName) { displayName('Platform Management') }
 
+def adopPlatformManagementVersion = (binding.variables.containsKey("ADOP_PLATFORM_MANAGEMENT_VERSION")) ? "${ADOP_PLATFORM_MANAGEMENT_VERSION}".toString() : '';
+def adopPlatformManagementVersionRef = '${ADOP_PLATFORM_MANAGEMENT_VERSION}';
+
+if (!adopPlatformManagementVersion.matches("[a-fA-F0-9]{8,40}")) {
+  out.println("[WARN] ADOP_PLATFORM_MANAGEMENT_VERSION is set to '" + adopPlatformManagementVersion + "' which is not a valid hash - defaulting to '*/master'")
+  adopPlatformManagementVersionRef = '*/master';
+}
+
 // Jobs
 def loadCartridgeJob = freeStyleJob(platformManagementFolderName + "/Load_Cartridge_List")
  
@@ -66,7 +74,7 @@ done < ${WORKSPACE}/platform-management/cartridges.txt''')
                 url("${platformToolsGitURL}")
                 credentials("adop-jenkins-master")
             }
-            branch("*/master")
+            branch(adopPlatformManagementVersionRef)
             relativeTargetDir('platform-management')
         }
     }

--- a/bootstrap/Platform_Management/Setup_Gerrit.groovy
+++ b/bootstrap/Platform_Management/Setup_Gerrit.groovy
@@ -4,6 +4,14 @@ def platformToolsGitURL = "ssh://jenkins@gerrit:29418/platform-management"
 def platformManagementFolderName= "/Platform_Management"
 def platformManagementFolder = folder(platformManagementFolderName) { displayName('Platform Management') }
 
+def adopPlatformManagementVersion = (binding.variables.containsKey("ADOP_PLATFORM_MANAGEMENT_VERSION")) ? "${ADOP_PLATFORM_MANAGEMENT_VERSION}".toString() : '';
+def adopPlatformManagementVersionRef = '${ADOP_PLATFORM_MANAGEMENT_VERSION}';
+
+if (!adopPlatformManagementVersion.matches("[a-fA-F0-9]{8,40}")) {
+  out.println("[WARN] ADOP_PLATFORM_MANAGEMENT_VERSION is set to '" + adopPlatformManagementVersion + "' which is not a valid hash - defaulting to '*/master'")
+  adopPlatformManagementVersionRef = '*/master';
+}
+
 // Jobs
 def setupGerritJob = freeStyleJob(platformManagementFolderName + "/Setup_Gerrit")
  
@@ -53,7 +61,7 @@ fi''')
                 url("${platformToolsGitURL}")
                 credentials("adop-jenkins-master")
             }
-            branch("*/master")
+            branch(adopPlatformManagementVersionRef)
             relativeTargetDir('platform-management')
         }
     }

--- a/bootstrap/Workspace_Management/Generate_Workspace.groovy
+++ b/bootstrap/Workspace_Management/Generate_Workspace.groovy
@@ -4,6 +4,14 @@ def platformToolsGitURL = "ssh://jenkins@gerrit:29418/platform-management"
 def workspaceManagementFolderName= "/Workspace_Management"
 def workspaceManagementFolder = folder(workspaceManagementFolderName) { displayName('Workspace Management') }
 
+def adopPlatformManagementVersion = (binding.variables.containsKey("ADOP_PLATFORM_MANAGEMENT_VERSION")) ? "${ADOP_PLATFORM_MANAGEMENT_VERSION}".toString() : '';
+def adopPlatformManagementVersionRef = '${ADOP_PLATFORM_MANAGEMENT_VERSION}';
+
+if (!adopPlatformManagementVersion.matches("[a-fA-F0-9]{8,40}")) {
+  out.println("[WARN] ADOP_PLATFORM_MANAGEMENT_VERSION is set to '" + adopPlatformManagementVersion + "' which is not a valid hash - defaulting to '*/master'")
+  adopPlatformManagementVersionRef = '*/master';
+}
+
 // Jobs
 def generateWorkspaceJob = freeStyleJob(workspaceManagementFolderName + "/Generate_Workspace")
  
@@ -72,7 +80,7 @@ done''')
                 url("${platformToolsGitURL}")
                 credentials("adop-jenkins-master")
             }
-            branch("*/master")
+            branch(adopPlatformManagementVersionRef)
         }
     }
 } 

--- a/projects/jobs/jobs.groovy
+++ b/projects/jobs/jobs.groovy
@@ -3,6 +3,14 @@ def gerritBaseUrl = "ssh://jenkins@gerrit:29418"
 def cartridgeBaseUrl = gerritBaseUrl + "/cartridges"
 def platformToolsGitUrl = gerritBaseUrl + "/platform-management"
 
+def adopPlatformManagementVersion = (binding.variables.containsKey("ADOP_PLATFORM_MANAGEMENT_VERSION")) ? "${ADOP_PLATFORM_MANAGEMENT_VERSION}".toString() : '';
+def adopPlatformManagementVersionRef = '${ADOP_PLATFORM_MANAGEMENT_VERSION}';
+
+if (!adopPlatformManagementVersion.matches("[a-fA-F0-9]{8,40}")) {
+  out.println("[WARN] ADOP_PLATFORM_MANAGEMENT_VERSION is set to '" + adopPlatformManagementVersion + "' which is not a valid hash - defaulting to '*/master'")
+  adopPlatformManagementVersionRef = '*/master';
+}
+
 // Folders
 def workspaceFolderName = "${WORKSPACE_NAME}"
 
@@ -418,7 +426,7 @@ def cartridgeFolder = folder(cartridgeFolderName) {
                 url("${platformToolsGitUrl}")
                 credentials("adop-jenkins-master")
             }
-            branch("*/master")
+            branch(adopPlatformManagementVersionRef)
         }
     }
 }

--- a/workspaces/jobs/jobs.groovy
+++ b/workspaces/jobs/jobs.groovy
@@ -1,6 +1,14 @@
 // Constants
 def platformToolsGitURL = "ssh://jenkins@gerrit:29418/platform-management"
 
+def adopPlatformManagementVersion = (binding.variables.containsKey("ADOP_PLATFORM_MANAGEMENT_VERSION")) ? "${ADOP_PLATFORM_MANAGEMENT_VERSION}".toString() : '';
+def adopPlatformManagementVersionRef = '${ADOP_PLATFORM_MANAGEMENT_VERSION}';
+
+if (!adopPlatformManagementVersion.matches("[a-fA-F0-9]{8,40}")) {
+  out.println("[WARN] ADOP_PLATFORM_MANAGEMENT_VERSION is set to '" + adopPlatformManagementVersion + "' which is not a valid hash - defaulting to '*/master'")
+  adopPlatformManagementVersionRef = '*/master';
+}
+
 // Folders
 def workspaceFolderName = "${WORKSPACE_NAME}"
 def workspaceFolder = folder(workspaceFolderName)
@@ -87,7 +95,7 @@ source ${WORKSPACE}/projects/gerrit/configure.sh -r permissions-with-review''')
                 url("${platformToolsGitURL}")
                 credentials("adop-jenkins-master")
             }
-            branch("*/master")
+            branch(adopPlatformManagementVersionRef)
         }
     }
 }


### PR DESCRIPTION
Updating the platform jobs to use the ADOP_PLATFORM_MANAGEMENT_VERSION to know what to checkout from adop-platform-management. If ADOP_PLATFORM_MANAGEMENT_VERSION has not been set in Jenkins then it will default to the old value of "*/master".

Originally I wanted to support using tags, but there's a problem with that because whilst the jobs that consume this repository can checkout a tag Load_Platform won't be able to push the tags because Gerrit won't allow it when it is first launched and I'm not keen on running another job after the access control job has run. So for now it will support commit IDs in ADOP_PLATFORM_MANAGEMENT_VERSION.

This depends on the following PRs:
- ~~Accenture/adop-jenkins#12~~
- ~~Accenture/adop-docker-compose#61~~
- ~~Accenture/adop-docker-compose#185~~
- ~~Accenture/adop-jenkins#41~~

Expected behaviour:
- If ADOP_PLATFORM_MANAGEMENT_VERSION is not present or is not a valid hash, default the ref to checkout to '*/master' as per the old functionality
- If ADOP_PLATFORM_MANAGEMENT_VERSION is added at a later date, Load_Platform will need to be run again to pickup the new changes and enable the use of the variable in the platform jobs
- If ADOP_PLATFORM_MANAGEMENT_VERSION is added at a later date, workspaces and projects will need recreating to enable the use of the variable once Load_Platform has been run

To test:
- Modify the Jenkins image version to be 0.2.7 in docker-compose.yml
- Spin it up using "--without-load"
- Edit Load_Platform to use my repo
- Run Load_Platform
- Verify all the jobs work as expected
- Add a global environment variable ADOP_PLATFORM_MANAGEMENT_VERSION in Manage Jenkins > Configure System and set it to the latest commit in my repo (i.e. the one for this PR)
- Run Load_Platform again
- Verify that the jobs are all using the correct commit ID
- Verify that all the jobs work as expected
- Change ADOP_PLATFORM_MANAGEMENT_VERSION to something else
- Run Load_Platform again
- Verify that the jobs are all using the correct commit ID (they should at least check out the specified one, whether or not they work is not the point, it will depend on what commit you pick)

To test and simulate the adop-docker-compose PR that will come from this?
- Edit docker-compose.yml to set ADOP_PLATFORM_MANAGEMENT_VERSION to the commit ID for this PR
- Spin it up using "--without-load"
- Edit Load_Platform to use my repo
- Run Load_Platform
- Verify that the jobs are all using the correct commit ID
- Verify that all the jobs work as expected