### PR TITLE
Making improvements to parameterization in jobs

### DIFF
--- a/bootstrap/Platform_Management/Load_Platform_Extension.groovy
+++ b/bootstrap/Platform_Management/Load_Platform_Extension.groovy
@@ -23,6 +23,7 @@ loadPlatformExtensionJob.with{
       git{
         remote{
           url('${GIT_URL}')
+          credentials("adop-jenkins-master")
         }
         branch('${GIT_REF}')
       }

--- a/bootstrap/Platform_Management/Load_Platform_Extension.groovy
+++ b/bootstrap/Platform_Management/Load_Platform_Extension.groovy
@@ -12,8 +12,12 @@ loadPlatformExtensionJob.with{
         sshAgent('adop-jenkins-master')
     }
     parameters{
-      stringParam("GIT_URL",'https://github.com/Accenture/sample-platform-extension.git',"The URL of the git repo for Platform Extension")
+      stringParam("GIT_URL",'',"The URL of the git repo for Platform Extension")
       stringParam("GIT_REF","master","The reference to checkout from git repo of Platform Extension. It could be a branch name or a tag name. Eg : master, 0.0.1 etc")
+      credentialsParam("AWS_CREDENTIALS"){
+        type('com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl')
+        description('AWS access key and secret key for your account')
+      }
     }
     scm{
       git{
@@ -30,7 +34,7 @@ loadPlatformExtensionJob.with{
       maskPasswords()
       sshAgent("adop-jenkins-master")
       credentialsBinding {
-        usernamePassword("AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "aws-environment-provisioning")
+        usernamePassword("AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", '${AWS_CREDENTIALS}')
       }
     }
     steps {

--- a/bootstrap/Platform_Management/Load_Platform_Extension_Collections.groovy
+++ b/bootstrap/Platform_Management/Load_Platform_Extension_Collections.groovy
@@ -10,6 +10,10 @@ def loadPlatformExtensionCollectionJob = workflowJob(platformManagementFolderNam
 loadPlatformExtensionCollectionJob.with{
     parameters{
         stringParam('COLLECTION_URL', '', 'URL to a JSON file defining your platform extension collection.')
+        credentialsParam("AWS_CREDENTIALS"){
+            type('com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl')
+            description('AWS access key and secret key for your account')
+        }
     }
     properties {
         rebuild {
@@ -37,7 +41,7 @@ loadPlatformExtensionCollectionJob.with{
         String url = data.extensions[i].url
         println("Platform Extension URL: " + url)
         String desc = data.extensions[i].description
-        build job: '/Platform_Management/Load_Platform_Extension', parameters: [[$class: 'StringParameterValue', name: 'GIT_URL', value: url], [$class: 'StringParameterValue', name: 'GIT_REF', value: 'master']]
+        build job: '/Platform_Management/Load_Platform_Extension', parameters: [[$class: 'StringParameterValue', name: 'GIT_URL', value: url], [$class: 'StringParameterValue', name: 'GIT_REF', value: 'master'], [$class: 'CredentialsParameterValue', name: 'AWS_CREDENTIALS', value: "${AWS_CREDENTIALS}"]]
     }
 
 }

--- a/projects/jobs/jobs.groovy
+++ b/projects/jobs/jobs.groovy
@@ -219,8 +219,6 @@ def cartridgeFolder = folder(cartridgeFolderName) {
 loadCartridgeCollectionJob.with{
     parameters{
         stringParam('COLLECTION_URL', '', 'URL to a JSON file defining your cartridge collection.')
-        stringParam('WORKSPACE_NAME', workspaceFolderName, 'Workspace namespace (DO NOT CHANGE FROM DEFAULT VALUE)')
-        stringParam('PROJECT_NAME', projectFolderName, 'Project namespace (DO NOT CHANGE FROM DEFAULT VALUE)')
     }
     properties {
         rebuild {
@@ -247,7 +245,7 @@ loadCartridgeCollectionJob.with{
     cartridgeCount = data.cartridges.size
     println "Number of cartridges: ${cartridgeCount}"
 
-    def projectWorkspace =  "${PROJECT_NAME}"
+    def projectWorkspace =  "''' + projectFolderName + '''"
     println "Project workspace: ${projectWorkspace}"
 
     // For loop iterating over the data map obtained from the provided JSON file


### PR DESCRIPTION
- AWS Credentials are now passed into Load_Platform_Extension as Credential parameter. so that the job doesn't have to be manually edited every time you add new AWS credentials

- Load_Cartridge_Collection earlier required input parameters for the workspace and project (which could have been edited causing the job to fail). Now we've added them in the groovy in a way that they appear hard-coded in the job so that they don't have to be passed in as parameters.

- Also defaulting platform extension git url to a blank string