### PR TITLE
Adding OVERWRITE_REPOS flag to Load Cartridge job.

### DIFF
--- a/projects/jobs/jobs.groovy
+++ b/projects/jobs/jobs.groovy
@@ -34,6 +34,7 @@ loadCartridgeJob.with{
         stringParam('FOLDER_DISPLAY_NAME', '', 'Display name of the folder where the cartridge is loaded.')
         stringParam('FOLDER_DESCRIPTION', '', 'Description of the folder where the cartridge is loaded.')
         booleanParam('ENABLE_CODE_REVIEW', false, 'Enables Gerrit Code Reviewing for the selected cartridge')
+        booleanParam('OVERWRITE_REPOS', false, 'If ticked, existing code repositories (previously loaded by the cartridge) will be overwritten. For first time cartridge runs, this property is redundant and will perform the same behavior regardless.')
     }
     environmentVariables {
         env('WORKSPACE_NAME',workspaceFolderName)
@@ -104,7 +105,13 @@ while read repo_url; do
         cd "${repo_name}"
         git remote add source "${repo_url}"
         git fetch source
-        git push origin +refs/remotes/source/*:refs/heads/*
+        if [ "$OVERWRITE_REPOS" == true ]; then
+            git push origin +refs/remotes/source/*:refs/heads/*
+        else
+            set +e
+            git push origin refs/remotes/source/*:refs/heads/*
+            set -e
+        fi
         cd -
     fi
 done < ${WORKSPACE}/cartridge/src/urls.txt


### PR DESCRIPTION
This will stop repositories being overwritten by default for every cartridge load.

The scenario that it **fixes** is the following:
- Person loads cartridge
- Cartridge creates repos
- Developer push to a repo that the catridge has created
- On load cartridge, repositories are completely overwritten (removes developers commits)

Tested several scenarios:
_Test1 - creating project to test groovy_
<img width="391" alt="test1 - creating project to test groovy" src="https://cloud.githubusercontent.com/assets/7059116/17668803/f12a3e44-6302-11e6-86d8-dd6b7f05aa3a.PNG">

_Test2 - performing load without tick box on new project_
<img width="670" alt="test2 - performing load without tick box on new project" src="https://cloud.githubusercontent.com/assets/7059116/17668807/f1340596-6302-11e6-82ea-1322bb40a975.PNG">

<img width="438" alt="proof2 - cartridge loaded successfully" src="https://cloud.githubusercontent.com/assets/7059116/17668799/f116d50c-6302-11e6-8eda-4a8b543c0297.PNG">

_Test3a - Adding commit into repository_
<img width="429" alt="test3a - adding comment" src="https://cloud.githubusercontent.com/assets/7059116/17668804/f12e91b0-6302-11e6-9465-53631498827b.PNG">

_Test3b - Loading cartridge unticked_
<img width="388" alt="test3b - loading cartridge unticked" src="https://cloud.githubusercontent.com/assets/7059116/17668805/f12edc2e-6302-11e6-9085-c3885f8de922.PNG">

<img width="429" alt="proof3b - commit still exists" src="https://cloud.githubusercontent.com/assets/7059116/17668800/f1176184-6302-11e6-94d4-3a57157ef3b7.PNG">

<img width="422" alt="proof3b - loaded cartridge" src="https://cloud.githubusercontent.com/assets/7059116/17668798/f114a9bc-6302-11e6-96da-4d3584ae9850.PNG">

_Test4 - Loading cartridge ticked_
<img width="359" alt="test4 - loading cartridge ticked" src="https://cloud.githubusercontent.com/assets/7059116/17668806/f13134ba-6302-11e6-9596-2dae07b129cb.PNG">

<img width="463" alt="proof4 - commit overwritten" src="https://cloud.githubusercontent.com/assets/7059116/17668801/f117f5a4-6302-11e6-8847-b70df1cbbae0.PNG">

_Test5 - Loading cartridge from beginning on new project ticked_
<img width="379" alt="test5 - loading cartridge from begginign on new project ticked" src="https://cloud.githubusercontent.com/assets/7059116/17668797/f114067e-6302-11e6-93fd-de44d9bbec14.PNG">

<img width="410" alt="proof5 - repos exist" src="https://cloud.githubusercontent.com/assets/7059116/17668802/f11ba460-6302-11e6-9744-821e56b5c094.PNG">