### PR TITLE
Arbitrary cartridge location (and two more cartridges for the default list)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+git-repos-vol
+elk-data-vol
+nexus-data-vol
+gerrit-site-vol
+volumes/elasticsearch-data-vol/elasticsearch/
+volumes/jenkins-home-vol
+*~
+*.swp
+*.swo
+platform.secrets.sh*

--- a/cartridges.txt
+++ b/cartridges.txt
@@ -1,4 +1,6 @@
 https://github.com/Accenture/adop-cartridge-java.git
 https://github.com/Accenture/adop-cartridge-cartridge-dev.git
 https://github.com/Accenture/adop-cartridge-chef.git
+https://github.com/Accenture/adop-cartridge-docker.git
 https://github.com/kramos/adop-cartridge-aspnet-linux.git
+https://github.com/kramos/adop-cartridge-flyway.git


### PR DESCRIPTION
In reference to issue #16 this updates the cartridge loader to support arbitrary locations of the cartridge in a repo (as detected by the location of metadata.cartridge).

I've tested it with:
https://github.com/kramos/alexia
Java cartridge
Chef cartridge
FlyWay cartridge.

I haven't tested a cartridge collection as I don't know where any live.  But it looks like it calls the load cartridge job, so is unlikely to fail.

To test this:
1. Run Load Platform against this fork.
2. Create new Workspaces and Projects
3. Load some cartrdiges.
