### PR TITLE
Fixed parser to JSON collections in Load_*_Collection jobs in Jenkins 2

### DIFF
--- a/bootstrap/Platform_Management/Load_Platform_Extension_Collections.groovy
+++ b/bootstrap/Platform_Management/Load_Platform_Extension_Collections.groovy
@@ -28,20 +28,19 @@ loadPlatformExtensionCollectionJob.with{
     sh("wget ${COLLECTION_URL} -O collection.json")
 
     println "Reading in values from file..."
-    Map data = parseJSON(readFile('collection.json'))
+    extensions = parseJSON(readFile('collection.json'))
 
-    println(data);
+    println(extensions);
     println "Obtained values locally...";
 
-    extensionCount = data.extensions.size
+    extensionCount = extensions.size
     println "Number of platform extensions: ${extensionCount}"
 
     // For loop iterating over the data map obtained from the provided JSON file
-    for ( i = 0 ; i < extensionCount ; i++ ) {
-        String url = data.extensions[i].url
-        println("Platform Extension URL: " + url)
-        String desc = data.extensions[i].description
-        build job: '/Platform_Management/Load_Platform_Extension', parameters: [[$class: 'StringParameterValue', name: 'GIT_URL', value: url], [$class: 'StringParameterValue', name: 'GIT_REF', value: 'master'], [$class: 'CredentialsParameterValue', name: 'AWS_CREDENTIALS', value: "${AWS_CREDENTIALS}"]]
+    for (int i = 0; i < extensionCount; i++) {
+        def extension = extensions.get(i);
+        println("Platform Extension URL: " + extension.url)
+        build job: '/Platform_Management/Load_Platform_Extension', parameters: [[$class: 'StringParameterValue', name: 'GIT_URL', value: extension.url], [$class: 'StringParameterValue', name: 'GIT_REF', value: 'master'], [$class: 'CredentialsParameterValue', name: 'AWS_CREDENTIALS', value: "${AWS_CREDENTIALS}"]]
     }
 
 }
@@ -51,7 +50,16 @@ loadPlatformExtensionCollectionJob.with{
     def slurper = new groovy.json.JsonSlurper();
     Map data = slurper.parseText(text)
     slurper = null
-    return data
+
+    def extensions = []
+    for ( i = 0 ; i < data.extensions.size; i++ ) {
+        String url = data.extensions[i].url
+        extensions[i] = ['url' : url]
+    }
+
+    data = null
+
+    return extensions
 }
             ''')
             sandbox()


### PR DESCRIPTION
Unfortunately, as we have to support Jenkins 1.* and Jenkins 2.* at the same time, we can't just use JsonSlurperClassic, we have to provide basically "work around" as you will find in this PR with two loops. So i rewrote the code to support both versions, tested on:
- Jenkins ver. 2.7.4
- Jenkins ver. 1.609.1

```
Since Groovy 2.3 (note: Jenkins 2.7.1 uses Groovy 2.4.7) JsonSlurper returns LazyMap instead of HashMap. This makes new implementation of JsonSlurper not thread safe and not serializable.
```

More details in internet:
- https://issues.jenkins-ci.org/browse/JENKINS-35140
- http://stackoverflow.com/questions/37864542/jenkins-pipeline-notserializableexception-groovy-json-internal-lazymap/37897833#37897833
- https://github.com/jenkinsci/pipeline-examples/blob/master/docs/BEST_PRACTICES.md#groovy-gotchas