### PR TITLE
Adding parent job to call platform setup jobs

### DIFF
--- a/bootstrap/Platform_Management/Job_Runner.groovy
+++ b/bootstrap/Platform_Management/Job_Runner.groovy
@@ -1,0 +1,29 @@
+// Constants
+
+def platformManagementFolderName= "/Platform_Management"
+def platformManagementFolder = folder(platformManagementFolderName) { displayName('Platform Management') }
+
+// Jobs
+def jobRunner = workflowJob(platformManagementFolderName + "/Job_Runner")
+ 
+// Setup setup_cartridge
+jobRunner.with{
+    description("This job is responsible for executing all required jobs under the Platform_Management folder to setup your platform")
+    properties {
+        rebuild {
+            autoRebuild(false)
+            rebuildDisabled(false)
+        }
+    }
+    definition {
+        cps {
+            script('''// Load the list of default cartridges
+build job: 'Platform_Management/Load_Cartridge_List'
+
+// Setup the Gerrit ACL
+build job: 'Platform_Management/Setup_Gerrit'
+''')
+sandbox()
+        }
+    }
+} 


### PR DESCRIPTION
Adding a workflow job which calls all the other setup jobs in Platform_Management i.e. Setup_Gerrit etc. The job itself is called by  Load_Platform

This makes it easier for us to add new setup jobs since we can just update adop-platform-management without having to constantly update Load_Platform, and hence adop-jenkins too.