### PR TITLE
Updating platform jobs for pluggable scm

### DIFF
--- a/bootstrap/Platform_Management/Job_Runner.groovy
+++ b/bootstrap/Platform_Management/Job_Runner.groovy
@@ -22,6 +22,9 @@ build job: 'Platform_Management/Load_Cartridge_List'
 
 // Setup the Gerrit ACL
 build job: 'Platform_Management/Setup_Gerrit'
+
+// Setup the Pluggable Library
+build job: 'Platform_Management/Setup_Pluggable_Library'
 ''')
 sandbox()
         }

--- a/bootstrap/Platform_Management/Setup_Pluggable_Library.groovy
+++ b/bootstrap/Platform_Management/Setup_Pluggable_Library.groovy
@@ -10,8 +10,8 @@ def setupPluggable = freeStyleJob(platformManagementFolderName + "/Setup_Pluggab
 // Setup setup_cartridge
 setupPluggable.with{
     environmentVariables {
-        keepBuildVariables()
-        keepSystemVariables()
+        keepBuildVariables(true)
+        keepSystemVariables(true)
     }
     wrappers {
         preBuildCleanup()

--- a/bootstrap/Platform_Management/Setup_Pluggable_Library.groovy
+++ b/bootstrap/Platform_Management/Setup_Pluggable_Library.groovy
@@ -1,0 +1,39 @@
+// Constants
+def pluggableGitURL = "https://github.com/Accenture/adop-pluggable-scm"
+
+def platformManagementFolderName= "/Platform_Management"
+def platformManagementFolder = folder(platformManagementFolderName) { displayName('Platform Management') }
+
+// Jobs
+def setupPluggable = freeStyleJob(platformManagementFolderName + "/Setup_Pluggable_Library")
+ 
+// Setup setup_cartridge
+setupPluggable.with{
+    environmentVariables {
+        keepBuildVariables()
+        keepSystemVariables()
+    }
+    wrappers {
+        preBuildCleanup()
+    }
+    steps {
+        shell('''#!/bin/bash -ex
+
+echo "Extracting Pluggable library to additonal classpath location: ${PLUGGABLE_SCM_PROVIDER_PATH}"
+cp -r src/main/groovy/pluggable/ ${PLUGGABLE_SCM_PROVIDER_PATH}
+echo "******************"
+
+echo "Library contents: "
+ls ${PLUGGABLE_SCM_PROVIDER_PATH}pluggable/scm/
+''')
+    }
+    scm {
+        git {
+            remote {
+                name("origin")
+                url("${pluggableGitURL}")
+            }
+            branch("*/master")
+        }
+    }
+} 

--- a/projects/jobs/jobs.groovy
+++ b/projects/jobs/jobs.groovy
@@ -2,7 +2,6 @@
 def gerritBaseUrl = "ssh://jenkins@gerrit:29418"
 def cartridgeBaseUrl = gerritBaseUrl + "/cartridges"
 def platformToolsGitUrl = gerritBaseUrl + "/platform-management"
-def scmPropertiesPath = "${PLUGGABLE_SCM_PROVIDER_PROPERTIES_PATH}"
 
 // Folders
 def workspaceFolderName = "${WORKSPACE_NAME}"

--- a/projects/jobs/jobs.groovy
+++ b/projects/jobs/jobs.groovy
@@ -109,21 +109,28 @@ return cartridge_urls;
         maskPasswords()
         credentialsBinding {
             file('SCM_SSH_KEY', 'adop-jenkins-private')
+        }        
+        copyToSlaveBuildWrapper {
+          includes("**/**")
+          excludes("")
+          flatten(false)
+          includeAntExcludes(false)
+          relativeTo('''${JENKINS_HOME}/userContent''')
+          hudsonHomeRelative(false)
         }
     }
+    label("!master")
     steps {
         shell('''#!/bin/bash -ex
 
-# Create temp directory for repositories
 mkdir ${WORKSPACE}/tmp
-
-# Copy pluggable SCM package into workspace
-mkdir ${WORKSPACE}/job_dsl_additional_classpath
-cp -r ${PLUGGABLE_SCM_PROVIDER_PATH}pluggable $WORKSPACE/job_dsl_additional_classpath
 
 # Output SCM provider ID to a properties file
 echo SCM_PROVIDER_ID=$(echo ${SCM_PROVIDER} | cut -d "(" -f2 | cut -d ")" -f1) > scm_provider_id.properties
 ''')
+        environmentVariables {
+            propertiesFile('scm_provider_id.properties')
+        }
         systemGroovyCommand('''
 import com.cloudbees.plugins.credentials.*;
 import com.cloudbees.plugins.credentials.common.*;
@@ -159,7 +166,7 @@ if(credentialId != null){
   fp.write("SCM_USERNAME="+credentialInfo[0]+"\\nSCM_PASSWORD="+credentialInfo[1], null);
 }
 '''){
-classpath('$WORKSPACE/job_dsl_additional_classpath/')
+classpath('${PLUGGABLE_SCM_PROVIDER_PATH}')
 }
         shell('''#!/bin/bash -ex
 
@@ -228,9 +235,6 @@ fi
         environmentVariables {
           propertiesFile('${WORKSPACE}/carthome.properties')
         }
-        environmentVariables {
-            propertiesFile('scm_provider_id.properties')
-        }
         systemGroovyCommand('''
 import jenkins.model.*;
 import groovy.io.FileType;
@@ -288,10 +292,12 @@ def projectFolderName = envVarProperty.getProperty('PROJECT_NAME')
 def cartridgeFolder = envVarProperty.getProperty('CARTRIDGE_FOLDER')
 def overwriteRepos = envVarProperty.getProperty('OVERWRITE_REPOS')
 
+def scmNamespace = '';
+
 if (envVarProperty.hasProperty('SCM_NAMESPACE')){
-  def scmNamespace = envVarProperty.getProperty('SCM_NAMESPACE')
+  scmNamespace = envVarProperty.getProperty('SCM_NAMESPACE')
 }else{
-  scmNamespace = ""
+  scmNamespace = ''
 }
 
 def codeReviewEnabled = envVarProperty.getProperty('ENABLE_CODE_REVIEW')

--- a/projects/jobs/jobs.groovy
+++ b/projects/jobs/jobs.groovy
@@ -121,7 +121,7 @@ return cartridge_urls;
           hudsonHomeRelative(false)
         }
     }
-    label("!master")
+    label("!master && !windows && !ios")
     steps {
         shell('''#!/bin/bash -ex
 

--- a/workspaces/jobs/jobs.groovy
+++ b/workspaces/jobs/jobs.groovy
@@ -15,6 +15,7 @@ def generateProjectJob = freeStyleJob(projectManagementFolderName + "/Generate_P
 generateProjectJob.with{
     parameters{
         stringParam("PROJECT_NAME","","The name of the project to be generated.")
+        booleanParam('CUSTOM_SCM_NAMESPACE', false, 'Enables the option to provide a custom project namespace for your SCM provider')
         stringParam("ADMIN_USERS","","The list of users' email addresses that should be setup initially as admin. They will have full access to all jobs within the project.")
         stringParam("DEVELOPER_USERS","","The list of users' email addresses that should be setup initially as developers. They will have full access to all non-admin jobs within the project.")
         stringParam("VIEWER_USERS","","The list of users' email addresses that should be setup initially as viewers. They will have read-only access to all non-admin jobs within the project.")


### PR DESCRIPTION
This pull request will update miscellaneous platform jobs to support Pluggable SCM:
* A new platform job to deploy the pluggable scm library in your Job DSL additional classpath
* Updates to Generate_Project to allow you to add a new parameter to Load_Cartridge, letting you set a custom namespace for your repos to be loaded under
* Updates to Load_Cartridge with a new parameter for SCM_PROVIDER and making it completely agnostic of your chosen SCM provider i.e. no references to Gerrit
* Supports running load cartridge and masters and unix/linux slaves.

Test Scenarios

* [x] Backwards compatibility: Load current Java Cartridge
** Expect spring petclinic repos to be created in Gerrit
* [x] Backwards compatibility: Load current DOA Cartridge Collection
- [x] Test Gerrit SCM Provider with SSH (Java Cartridge)
- [x] Test Gerrit SCM Provider with SSH and without a cartridge folder name
- [x] Test Gerrit SCM Provider with HTTPS (Java Cartridge)
- [x] Test Gerrit SCM Provider with HTTPS and without a cartridge folder name (Java Cartridge)

As the build label is also set to !master the above tests should also confirm we can run the cartridge loader from unix/linux based slaves.

For all tests it is expected the respective repositories captured in urls.txt will be created with the respective SCM provider (Gerrit, BitBucket)

This PR is dependent on:
~~https://github.com/Accenture/adop-jenkins/pull/29~~
~~https://github.com/Accenture/adop-docker-compose/pull/187~~
~~https://github.com/Accenture/adop-pluggable-scm/pull/4~~