### PR TITLE
Adding defaulted parameter in example workspace generation

### DIFF
--- a/bootstrap/Platform_Management/Generate_Example_Workspace.groovy
+++ b/bootstrap/Platform_Management/Generate_Example_Workspace.groovy
@@ -2,6 +2,10 @@
 def platformManagementFolderName= "/Platform_Management"
 def platformManagementFolder = folder(platformManagementFolderName) { displayName('Platform Management') }
 
+def rootUrl = "${ROOT_URL}"
+gerritRootUrl = rootUrl.replaceAll("jenkins","gerrit")
+
+
 // Jobs
 def generateExampleWorkspaceJob = workflowJob(platformManagementFolderName + "/Generate_Example_Workspace")
  
@@ -16,6 +20,7 @@ generateExampleWorkspaceJob.with{
         stringParam("workspaceDeveloper","Developer","")
         stringParam("workspaceViewer","Viewer","")
         stringParam("cartridgeURL","ssh://jenkins@gerrit:29418/cartridges/adop-cartridge-java.git","")
+        stringParam("scmProvider",gerritRootUrl + " - ssh (adop-gerrit-ssh)","")
     }
     properties {
         rebuild {
@@ -31,7 +36,7 @@ build job: 'Workspace_Management/Generate_Workspace', parameters: [[$class: 'Str
 // Setup Faculty
 build job: "${workspaceName}/Project_Management/Generate_Project", parameters: [[$class: 'StringParameterValue', name: 'PROJECT_NAME', value: "${projectName}"], [$class: 'StringParameterValue', name: 'ADMIN_USERS', value: "${projectName}${projectAdmin}"], [$class: 'StringParameterValue', name: 'DEVELOPER_USERS', value: "${projectName}${projectDeveloper}"], [$class: 'StringParameterValue', name: 'VIEWER_USERS', value: "${projectName}${projectViewer}"]]
 retry(5) {
-    build job: "${workspaceName}/${projectName}/Cartridge_Management/Load_Cartridge", parameters: [[$class: 'StringParameterValue', name: 'CARTRIDGE_CLONE_URL', value: "${cartridgeURL}"]]
+    build job: "${workspaceName}/${projectName}/Cartridge_Management/Load_Cartridge", parameters: [[$class: 'StringParameterValue', name: 'CARTRIDGE_CLONE_URL', value: "${cartridgeURL}"], [$class: 'StringParameterValue', name: 'SCM_PROVIDER', value: "${scmProvider}"]]
 }''')
 sandbox()
         }


### PR DESCRIPTION
Generate_Example_Workspace by default doesn't set the SCM_PROVIDER parameter in Load_Cartridge, thus it isn't able to load a cartidge in by default in the ExampleWorkspace