### PR TITLE
Fixed issue with http(s) credentials for bitbucket on prem SCM provider

### DIFF
--- a/projects/jobs/jobs.groovy
+++ b/projects/jobs/jobs.groovy
@@ -213,10 +213,16 @@ export GIT_SSH="${WORKSPACE}/custom_ssh"
 # Clone Cartridge
 echo "INFO: cloning ${CARTRIDGE_CLONE_URL}"
 # we do not want to show the password
+
 set +x
-if ( [ ${CARTRIDGE_CLONE_URL%://*} == "https" ] ||  [ ${CARTRIDGE_CLONE_URL%://*} == "http" ] ) && [ -f ${WORKSPACE}/${SCM_KEY} ]; then
-	source ${WORKSPACE}/${SCM_KEY}
-	git clone ${CARTRIDGE_CLONE_URL%://*}://${SCM_USERNAME}:${SCM_PASSWORD}@${CARTRIDGE_CLONE_URL#*://} cartridge
+PROTOCOL=${CARTRIDGE_CLONE_URL%://*}
+SCM_KEY_PATH=${WORKSPACE}@tmp/secretFiles/${SCM_KEY}
+
+if ( [ ${PROTOCOL} == "https" ] || [ ${PROTOCOL} == "http" ] ) && [ -f ${SCM_KEY_PATH} ]; then
+
+    BITBUCKET_REPOSITORY="${CARTRIDGE_CLONE_URL#*@}"
+    source ${SCM_KEY_PATH}
+    git clone ${PROTOCOL}://${SCM_USERNAME}:${SCM_PASSWORD}@${BITBUCKET_REPOSITORY} cartridge
 else
     git clone ${CARTRIDGE_CLONE_URL} cartridge
 fi


### PR DESCRIPTION
## 1. Fixing issue with credentials file
The first error was related was a wrong path for SCM_KEY file.
```
fatal: could not read Password for 'https://robert.isla@innersource.accenture.com': No such device or address
Build step 'Execute shell' marked build as failure
```
So, in order to be able to read the credentials from SCM_KEY file I changed the path from:

```[ -f ${WORKSPACE}/${SCM_KEY} ]```

To

```[ -f ${WORKSPACE}@tmp/secretFiles/${SCM_KEY} ]```

## 2. Issue with URL

The second issue was related with the **CARTRIDGE_CLONE_URL**. It was using the whole URL and that was an error because just need the source URL without the username in the beginning. So the code was changed from:
```
git clone ${CARTRIDGE_CLONE_URL%://*}://${SCM_USERNAME}:${SCM_PASSWORD}@${CARTRIDGE_CLONE_URL#*://} cartridge
```

To:
```
git clone ${PROTOCOL}://${SCM_USERNAME}:${SCM_PASSWORD}@${BITBUCKET_REPOSITORY} cartridge
``` 
Where **PROTOCOL** and **BITBUCKET_REPOSITORY** are:

```
PROTOCOL=${CARTRIDGE_CLONE_URL%://*}
BITBUCKET_REPOSITORY="${CARTRIDGE_CLONE_URL#*@}"
```


