### PR TITLE
Added custom cartridge properties multi-line text field to load cartridge

### DIFF
--- a/projects/jobs/jobs.groovy
+++ b/projects/jobs/jobs.groovy
@@ -146,6 +146,7 @@ return providerList;
         stringParam('CARTRIDGE_FOLDER', '', 'The folder within the project namespace where your cartridge will be loaded into.')
         stringParam('FOLDER_DISPLAY_NAME', '', 'Display name of the folder where the cartridge is loaded.')
         stringParam('FOLDER_DESCRIPTION', '', 'Description of the folder where the cartridge is loaded.')
+        textParam('CARTRIDGE_CUSTOM_PROPERTIES', '', 'Custom cartridge properties .e.g sonar.projectKey=adop')
         booleanParam('ENABLE_CODE_REVIEW', false, 'Enables Code Reviewing for the selected cartridge')
         booleanParam('OVERWRITE_REPOS', false, 'If ticked, existing code repositories (previously loaded by the cartridge) will be overwritten. For first time cartridge runs, this property is redundant and will perform the same behavior regardless.')
     }


### PR DESCRIPTION
Added custom cartridge properties multi-line text field to load cartridge to support custom properties

e.g.
sonar.projectKey=adop
openshift.projectName=adop-dev

Cartridges can then parse this text field and be configured according to the provided properties. Cartridges that adopt approach will have greater  re-usability. 

The library to consume these custom properties can be found here: https://github.com/RobertNorthard/adop-dsl-custom-cartridge-properties

I have also updated the skeleton cartridge as an example of how to use the library:
https://github.com/Accenture/adop-cartridge-skeleton/pull/6

Signed-off-by: Northard, Robert A <robert.a.northard@accenture.com>